### PR TITLE
React Navigation

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,40 +1,30 @@
-import React, { Component, PropTypes } from 'react';
-import { NavigatorIOS, Text, View, TouchableHighlight } from 'react-native';
+import React from 'react';
+import { StackNavigator } from 'react-navigation';
+import { Text, View, TouchableHighlight } from 'react-native';
+import LoginOrRegister from './screens/LoginOrRegister';
+import Dashboard from './screens/Dashboard';
 
-export default class NavigatorIOSApp extends Component {
+// The AppStack is the toplevel StackNavigator for your app
+// Here, you would do things like Authentication, OAuth, etc
+const AppStack = StackNavigator({
+  Home: {
+    screen: LoginOrRegister,
+    path: '/',
+    header: null
+  },
+  Dashboard: {
+    screen: Dashboard,
+    path: '/dashboard/:name',
+    header: null
+  }
+}, {
+  headerMode: 'none'
+});
+
+export default class App extends React.Component {
   render() {
     return (
-      <NavigatorIOS
-        initialRoute={{
-          component: MyScene,
-          title: 'My Initial Scene',
-        }}
-        style={{flex: 1}}
-      />
+      <AppStack />
     );
-  }
-}
-
-class MyScene extends Component {
-  static propTypes = {
-    // title: PropTypes.string.isRequired,
-    navigator: PropTypes.object.isRequired,
-  }
-
-  _onForward = () => {
-    this.props.navigator.push({
-      title: 'Scene ' + nextIndex,
-    });
-  }
-
-  render() {
-    return (
-      <View>
-        <Text>Current Scene: { this.props.title }</Text>
-        <TouchableHighlight onPress={this._onForward}>
-          <Text>Tap me to load the next scene</Text>
-        </TouchableHighlight>
-      </View>
-    )
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "react-native-scripts": "0.0.31",
     "jest-expo": "~1.0.1",
+    "react-native-scripts": "0.0.31",
     "react-test-renderer": "16.0.0-alpha.6"
   },
   "main": "./node_modules/react-native-scripts/build/bin/crna-entry.js",
@@ -21,6 +21,7 @@
   "dependencies": {
     "expo": "^17.0.0",
     "react": "16.0.0-alpha.6",
-    "react-native": "^0.44.0"
+    "react-native": "^0.44.0",
+    "react-navigation": "^1.0.0-beta.11"
   }
 }

--- a/screens/Dashboard/Cage/Faceoff.js
+++ b/screens/Dashboard/Cage/Faceoff.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Image, Text, View, TouchableHighlight } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { NavigationActions } from 'react-navigation';
+
+export default class Faceoff extends React.Component {
+  backToLowrider = () => {
+    const { navigation } = this.props;
+    navigation.goBack();
+  };
+
+  render() {
+    return (
+      <View style={{flex: 1, padding: 20}}>
+        <Image source={{uri: 'http://i.imgur.com/yHTbKyf.gif'}} resizeMode="contain" style={{height: 300, width: 300}} />
+        <TouchableHighlight onPress={this.backToLowrider}>
+          <Text style={{fontSize: 24}}>....let's ride</Text>
+        </TouchableHighlight>
+      </View>
+    );
+  }
+}

--- a/screens/Dashboard/Cage/Lowrider.js
+++ b/screens/Dashboard/Cage/Lowrider.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Image, Text, View, TouchableHighlight } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export default class Lowrider extends React.Component {
+  navigateTo = (cageScreenName) => {
+    const { navigation } = this.props;
+    navigation.navigate(cageScreenName);
+  };
+  render() {
+    return (
+      <View style={{flex: 1, padding: 20}}>
+        <Image source={{uri: 'http://i.imgur.com/TE9Vqvx.gif'}} resizeMode="contain" style={{height: 300, width: 300}} />
+        <TouchableHighlight onPress={this.navigateTo.bind(null, 'Faceoff')}>
+          <Text style={{fontSize: 24}}>Face...off.</Text>
+        </TouchableHighlight>
+      </View>
+    );
+  }
+}

--- a/screens/Dashboard/Cage/index.js
+++ b/screens/Dashboard/Cage/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StackNavigator } from 'react-navigation';
+import { Image, Text, View, TouchableHighlight } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import Faceoff from './Faceoff';
+import Lowrider from './Lowrider';
+
+const CageStack = StackNavigator({
+  Lowrider: {
+    screen: Lowrider,
+    path: '/cage/lowrider'
+  },
+  Faceoff: {
+    screen: Faceoff,
+    path: '/cage/faceoff'
+  }
+}, {
+  headerMode: 'none'
+});
+
+export default class Cage extends React.Component {
+  // Define these for TabNavigator screens
+  static navigationOptions = {
+    header: null,
+    tabBarLabel: 'Cage',
+    tabBarIcon: ({ tintColor }) => {
+      return <Ionicons name="ios-unlock" size={32} color={tintColor} />
+    }
+  };
+
+  render() {
+    return (
+      <CageStack />
+    )
+  }
+}

--- a/screens/Dashboard/Home.js
+++ b/screens/Dashboard/Home.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { StackNavigator } from 'react-navigation';
+import { Image, Text, View, TouchableHighlight } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { NavigationActions } from 'react-navigation';
+
+export default class Main extends React.Component {
+  // Define these for TabNavigator screens
+  static navigationOptions = {
+    header: null,
+    tabBarLabel: 'Main',
+    tabBarIcon: ({ tintColor }) => {
+      return <Ionicons name="ios-home" size={32} color={tintColor} />
+    }
+  };
+
+  logout = () => {
+    // We pass this down as screenProps from Dashboard/index.js, we need access to the parent stack to "logout"
+    const { appStack } = this.props.screenProps;
+    appStack.goBack();
+  };
+
+  render() {
+    // See: /screens/LoginOrRegister/index.js, this is the root level StackNavigator
+    const { appStack } = this.props.screenProps;
+
+    return (
+      <View style={{padding: 20}}>
+        <Text>Hi, {appStack.state.params.name}</Text>
+        <TouchableHighlight onPress={this.logout}>
+          <Text style={{fontSize: 24}}>Logout</Text>
+        </TouchableHighlight>
+      </View>
+    )
+  }
+}

--- a/screens/Dashboard/index.js
+++ b/screens/Dashboard/index.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { View, TouchableHighlight, Text } from 'react-native';
+import { TabNavigator } from 'react-navigation';
+import Home from './Home';
+import Cage from './Cage';
+
+const DashboardTabs = TabNavigator({
+  Home: {
+    screen: Home
+  },
+  Cage: {
+    screen: Cage
+  }
+});
+
+export default class Dashboard extends React.Component {
+  render() {
+    const { navigation } = this.props; // Add a reference to the top-level StackNavigator for logout scenarios
+    return (
+      <DashboardTabs screenProps={{appStack: navigation}} />
+    );
+  }
+}

--- a/screens/LoginOrRegister/index.js
+++ b/screens/LoginOrRegister/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Text, View, TouchableHighlight, Image } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+export default class LoginOrRegister extends React.Component {
+  navigateToDashboard = () => {
+    const { navigation } = this.props;
+    navigation.navigate('Dashboard', {name: 'Doc Stanton'}); 
+  };
+
+  render() {
+    return (
+      <View style={{padding: 20}}>
+        <Text>LoginOrRegister Screen</Text>
+        <TouchableHighlight onPress={this.navigateToDashboard}>
+          <Text style={{fontSize: 24}}>Login to Dashboard</Text>
+        </TouchableHighlight>
+      </View>
+    )
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1432,6 +1432,10 @@ ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
 
+clamp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/clamp/-/clamp-1.0.1.tgz#66a0e64011816e37196828fdc8c8c147312c8634"
+
 cli-cursor@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
@@ -2136,7 +2140,7 @@ fbjs-scripts@^0.7.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.4, fbjs@^0.8.9, fbjs@~0.8.9:
+fbjs@^0.8.12, fbjs@^0.8.4, fbjs@^0.8.9, fbjs@~0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -2509,7 +2513,7 @@ hoek@4.x.x:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.1.1.tgz#9cc573ffba2b7b408fb5e9c2a13796be94cddce9"
 
-hoist-non-react-statics@^1.0.3:
+hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
@@ -3686,11 +3690,7 @@ mz@^2.6.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
-nan@^2.3.3:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
-
-nan@~2.4.0:
+nan@^2.3.3, nan@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
 
@@ -3986,6 +3986,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -4198,6 +4204,22 @@ react-native-branch@2.0.0-beta.3:
   version "2.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz#2167af86bbc9f964bd45bd5f37684e5b54965e32"
 
+react-native-dismiss-keyboard@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz#32886242b3f2317e121f3aeb9b0a585e2b879b49"
+
+react-native-drawer-layout-polyfill@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout-polyfill/-/react-native-drawer-layout-polyfill-1.3.1.tgz#b514e34dec22c856b1e9e7253162e0af7d0eb4f0"
+  dependencies:
+    react-native-drawer-layout "1.3.1"
+
+react-native-drawer-layout@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-drawer-layout/-/react-native-drawer-layout-1.3.1.tgz#eb976df8fc43844811acebeed109029395406fe9"
+  dependencies:
+    react-native-dismiss-keyboard "1.0.0"
+
 "react-native-fbads@https://github.com/callstack-io/react-native-fbads/tarball/v4.1.0":
   version "4.1.0"
   resolved "https://github.com/callstack-io/react-native-fbads/tarball/v4.1.0#e836ed7f4502593d4a4757f27cdfa0ffef4dc729"
@@ -4237,6 +4259,12 @@ react-native-scripts@0.0.31:
   dependencies:
     color "^0.11.1"
     lodash "^4.16.6"
+
+react-native-tab-view@^0.0.65:
+  version "0.0.65"
+  resolved "https://registry.yarnpkg.com/react-native-tab-view/-/react-native-tab-view-0.0.65.tgz#b685ea3081ff7c96486cd997361026c407302c59"
+  dependencies:
+    prop-types "^15.5.8"
 
 react-native-vector-icons@4.1.1:
   version "4.1.1"
@@ -4331,6 +4359,18 @@ react-native@^0.44.0:
     xmldoc "^0.4.0"
     xpipe "^1.0.5"
     yargs "^6.4.0"
+
+react-navigation@^1.0.0-beta.11:
+  version "1.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-1.0.0-beta.11.tgz#4271edb23cdbcc6eb88602f7fde0a77f0ef7a160"
+  dependencies:
+    clamp "^1.0.1"
+    fbjs "^0.8.12"
+    hoist-non-react-statics "^1.2.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.5.10"
+    react-native-drawer-layout-polyfill "^1.3.0"
+    react-native-tab-view "^0.0.65"
 
 react-proxy@^1.1.7:
   version "1.1.8"
@@ -5412,11 +5452,7 @@ whatwg-encoding@^1.0.1:
   dependencies:
     iconv-lite "0.4.13"
 
-whatwg-fetch@>=0.10.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
-
-whatwg-fetch@^1.0.0:
+whatwg-fetch@>=0.10.0, whatwg-fetch@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-1.1.1.tgz#ac3c9d39f320c6dce5339969d054ef43dd333319"
 


### PR DESCRIPTION
#1 cc @gotoplanb 

## Prerequisites

1. Clone the repo
2. `yarn install`
3. `yarn start`
4. Launch Expo.io on your device, scan the resulting QR code

## Explanation

Hey Dave, this is easily my favorite navigation library in React Native, and the community seems to be rallying around it.  I really like its expandability and performance on Native, so here's a fairly elaborate example that demonstrates it.  Definitely do *not* use NavigatorIOS or the built-in Navigator for React Native.  I believe that, unofficially, `react-navigation` will be the "blessed" Navigator for React Native going forward.

Basically, with react-navigation, [we have different types of Navigators](https://reactnavigation.org/docs/navigators/)

In this particular example, I threw in as "real" of a use case as I could for a basic app with the help of my friend and yours, Nicolas Cage.

The app's navigator hierarchy is structured like so...

* AppStack -> StackNavigator
  * LoginOrRegister -> React.Component
  * DashboardTabs -> TabNavigator
   * Home -> React.Component
   * CageStack -> StackNavigator
     * Lowrider -> React.Component
     * Faceoff -> React.Component

So basically, you have one overarching StackNavigator to control things like Auth and Logout.  Then you have an actual `Dashboard` screen as a child of this main `AppStack`.

In reality, the `Dashboard` screen really returns another type of Navigator, in this case a `TabNavigator` like we're all used to in mobile

Inside the `TabNavigator` are two children: a `Home` screen, which is just a plain jane React.Component, and a `Cage` screen.  Guess what?  Nicolas Cage, in his wily ways, decides that his screen is yet another `TabNavigator` which highlights some of his greatest hits.
 
## Bonus!

react-navigation is also web-compatible.  I haven't given it a shot yet, but with the latest crap going on w/ `react-router`, I'm really tempted to try this as a potential client-side routing option.
